### PR TITLE
Use destructor hooks

### DIFF
--- a/cppstl.nimble
+++ b/cppstl.nimble
@@ -14,3 +14,12 @@ backend = "cpp"
 
 task gendoc, "gen doc":
   exec("nimble doc --backend:cpp --project cppstl.nim --out:docs/")
+
+task test, "Run the tests":
+  # run the manually to change the compilation flags
+  exec "nim cpp -r tests/destroy_bug_15.nim"
+  exec "nim cpp -r tests/tvector.nim"
+  exec "nim cpp -r tests/tstring.nim"
+  exec "nim cpp -r tests/tcomplex.nim"
+  # the following should compile and *not* produce a codegen error
+  exec "nim cpp --gc:arc -r tests/tdestructor_codegen_bug.nim"

--- a/cppstl/std_smartptrs.nim
+++ b/cppstl/std_smartptrs.nim
@@ -14,7 +14,7 @@ func make_shared*(T: typedesc): CppSharedPtr[T] {.importcpp: "std::make_shared<'
 when defined(gcDestructors):
   # TODO Fix copy on shared_ptr
   proc `=copy`*[T](dst: var CppSharedPtr[T], src: CppSharedPtr[T]) {.error: "A shared_ptr cannot be copied".}
-  # proc `=destroy`*[T](dst: var CppSharedPtr[T]){.importcpp: "#.~'*1()".}
+  proc `=destroy`*[T](dst: var CppSharedPtr[T]){.importcpp: "#.~'*1()".}
   # proc `=sink`*[T](dst: var CppSharedPtr[T], src: CppSharedPtr[T]){.importcpp: "# = std::move(#)".}
 
 # std::unique_ptr<T>
@@ -26,7 +26,7 @@ func make_unique*(T: typedesc): CppUniquePtr[T] {.importcpp: "std::make_unique<'
 
 when defined(gcDestructors):
   proc `=copy`*[T](dst: var CppUniquePtr[T], src: CppUniquePtr[T]) {.error: "A unique ptr cannot be copied".}
-  # proc `=destroy`*(dst: var CppUniquePtr[T]){.importcpp: "#.~'*1()".}
+  proc `=destroy`*(dst: var CppUniquePtr[T]){.importcpp: "#.~'*1()".}
   # proc `=sink`*(dst: var CppUniquePtr[T], src: CppUniquePtr[T]){.importcpp: "# = std::move(#)".}
 
 {.pop.}
@@ -65,4 +65,3 @@ macro `.=`*[T](p: CppUniquePtr[T] or CppSharedPtr[T], fieldOrFunc: untyped, args
   )
   #echo result.repr
   #copyChildrenTo(args, result)
-

--- a/cppstl/std_smartptrs.nim
+++ b/cppstl/std_smartptrs.nim
@@ -26,8 +26,8 @@ func make_unique*(T: typedesc): CppUniquePtr[T] {.importcpp: "std::make_unique<'
 
 when defined(gcDestructors):
   proc `=copy`*[T](dst: var CppUniquePtr[T], src: CppUniquePtr[T]) {.error: "A unique ptr cannot be copied".}
-  proc `=destroy`*(dst: var CppUniquePtr[T]){.importcpp: "#.~'*1()".}
-  # proc `=sink`*(dst: var CppUniquePtr[T], src: CppUniquePtr[T]){.importcpp: "# = std::move(#)".}
+  proc `=destroy`*[T](dst: var CppUniquePtr[T]){.importcpp: "#.~'*1()".}
+  # proc `=sink`*[T](dst: var CppUniquePtr[T], src: CppUniquePtr[T]){.importcpp: "# = std::move(#)".}
 
 {.pop.}
 

--- a/tests/tdestructor_codegen_bug.nim
+++ b/tests/tdestructor_codegen_bug.nim
@@ -1,0 +1,14 @@
+# without the definiton of the `=destroy` hook this gives a code gen error
+import cppstl/std_smartptrs
+
+type
+  Obj = object
+  XorNet = CppSharedPtr[Obj]
+
+proc init*(T: type XorNet): XorNet =
+  discard
+
+proc main() =
+  var model = XorNet.init()
+
+main()


### PR DESCRIPTION
Without the destructor hooks trying to use Flambeau with ARC is not possible, as it generates codegen errors. 

Not sure if there was a reason you did not use them previously?

edit: ok, now saw the issue https://github.com/Clonkk/nim-cppstl/issues/15.