### PR TITLE
Fix for Nim 2.0.0 - 2.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ requires "cppstl"
 
 ## Limitations
 
-``cppstl`` currently wraps :
+#### ``cppstl`` currently wraps :
 
 * ``std::string``
 * ``std::basic_string``
@@ -38,6 +38,26 @@ requires "cppstl"
 * Smart pointers are partially supported:
   * ``std::unique_ptr``
   * ``std::shared_ptr``
+
+#### Avoid using wrapped STL objects in top-level Nim scope.
+  Most of the times it works on Nim 1.x but leads to both compile-time and runtime errors on 2.x.
+  So instantiate them in subroutines only to ensure portability between 1.x and 2.x.
+
+I.e this usecase is not recommended: 
+```
+when isMainModule:
+  var vec = initCppVector[int]()
+  vec.pushBack(20)
+```
+Use this one instead:
+```
+when isMainModule:
+  proc foo = 
+    var vec = initCppVector[int]()
+    vec.pushBack(20)
+  foo()
+```
+
 
 ## Contributions
 

--- a/cppstl/std_string.nim
+++ b/cppstl/std_string.nim
@@ -24,7 +24,7 @@ proc initCppString*(s: cstring, n: csize_t): CppString {.constructor, importcpp:
 proc initCppString*(first, last: CppStrConstIterator): CppString {.constructor, importcpp: "std::string(@)".}
 
 # Modifiers
-proc `+=`*(self: var CppString, str: cstring) {.importcpp: "# += #".}
+proc `+=`*(self: var CppString, str: cstring) {.importcpp: "(# += #)".}
 
 proc append*(self: var CppString, str: cstring) {.importcpp: "append".}
 proc append*(self: var CppString, str: cstring, n: csize_t) {.importcpp: "append".}
@@ -70,6 +70,14 @@ proc compare*(self: CppString, pos, l: csize_t, str: cstring, subpos, subl: csiz
 
 # Converter: CppStrIterator -> StrConstIterator
 converter CppStrIteratorToStrConstIterator*(s: CppStrIterator): CppStrConstIterator {.importcpp: "#".}
+
+# Relational operators
+proc `==`*(a: CppString, b: CppString): bool {.importcpp: "(# == #)".}
+proc `!=`*(a: CppString, b: CppString): bool {.importcpp: "(# != #)".}
+proc `<`*(a: CppString, b: CppString): bool  {.importcpp: "(# < #)".}
+proc `<=`*(a: CppString, b: CppString): bool {.importcpp: "(# <= #)".}
+proc `>`*(a: CppString, b: CppString): bool  {.importcpp: "(# > #)".}
+proc `>=`*(a: CppString, b: CppString): bool {.importcpp: "(# >= #)".}
 
 {.pop.}
 

--- a/cppstl/std_vector.nim
+++ b/cppstl/std_vector.nim
@@ -246,7 +246,7 @@ proc erase*[T](self: var CppVector[T], first, last: CppVectorConstIterator[T]): 
 proc clear*[T](self: var CppVector[T]) {.importcpp: "clear".}
 
 # Relational operators
-proc `==`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# == #".} =
+proc `==`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# == #)".} =
   ## Return `true` if the contents of lhs and rhs are equal, that is,
   ## they have the same number of elements and each element in lhs compares
   ## equal with the element in rhs at the same position.
@@ -258,7 +258,7 @@ proc `==`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# == #".} =
       v2 = v1
     doAssert v1 == v2
 
-proc `!=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# != #".} =
+proc `!=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# != #)".} =
   ## Return `true` if the contents of lhs and rhs are not equal, that is,
   ## either they do not have the same number of elements, or one of the elements
   ## in lhs does not compare equal with the element in rhs at the same position.
@@ -276,7 +276,7 @@ proc `!=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# != #".} =
     v3[0] = 100
     doAssert v3 != v1
 
-proc `<`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# < #".} =
+proc `<`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# < #)".} =
   ## Return `true` if `a` is `lexicographically <https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare>`_
   ## less than `b`.
   ##
@@ -294,7 +294,7 @@ proc `<`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# < #".} =
     v2[2] = 0
     doAssert v2 < v1
 
-proc `<=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# <= #".} =
+proc `<=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# <= #)".} =
   ## Return `true` if `a` is `lexicographically <https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare>`_
   ## less than or equal to `b`.
   ##
@@ -312,7 +312,7 @@ proc `<=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# <= #".} =
     v2[2] = 0
     doAssert v2 <= v1
 
-proc `>`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# > #".} =
+proc `>`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# > #)".} =
   ## Return `true` if `a` is `lexicographically <https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare>`_
   ## greater than `b`.
   ##
@@ -330,7 +330,7 @@ proc `>`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# > #".} =
     v2[2] = 0
     doAssert v1 > v2
 
-proc `>=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "# >= #".} =
+proc `>=`*[T](a: CppVector[T], b: CppVector[T]): bool {.importcpp: "(# >= #)".} =
   ## Return `true` if `a` is `lexicographically <https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare>`_
   ## greater than or equal to `b`.
   ##

--- a/tests/tcomplex.nim
+++ b/tests/tcomplex.nim
@@ -3,83 +3,86 @@ import unittest
 import complex
 import cppstl/std_complex
 
-suite "CppComplex":
-  test "constructors":
-    var a = initCppComplex[float32](41.0, 31.0)
-    var refa = Complex32(re: 41.0, im: 31.0)
-    check refa.re == a.real
-    check refa.im == a.imag
+proc test = 
+  suite "CppComplex":
+    test "constructors":
+      var a = initCppComplex[float32](41.0, 31.0)
+      var refa = Complex32(re: 41.0, im: 31.0)
+      check refa.re == a.real
+      check refa.im == a.imag
 
-  test "Operators":
-    block:
+    test "Operators":
+      block:
+        var
+          a = initCppComplex[float64](141.571, 124.412)
+          b = initCppComplex[float64](22.17843, 0.523)
+          refa = toComplex(a)
+          refb = toComplex(b)
+          refres = refa+refb
+          res = a+b
+        check res == toCppComplex(refres)
+      block:
+        var
+          a = initCppComplex[float64](141.571, 124.412)
+          b = initCppComplex[float64](22.17843, 0.523)
+          refa = toComplex(a)
+          refb = toComplex(b)
+          refres = refa-refb
+          res = a-b
+        check res == toCppComplex(refres)
+      block:
+        var
+          a = initCppComplex[float64](141.571, 124.412)
+          b = initCppComplex[float64](22.17843, 0.523)
+          refa = toComplex(a)
+          refb = toComplex(b)
+          refres = refa*refb
+          res = a*b
+        check res == toCppComplex(refres)
+      block:
+        var
+          a = initCppComplex[float64](141.571, 124.412)
+          b = initCppComplex[float64](22.17843, 0.523)
+          refa = toComplex(a)
+          refb = toComplex(b)
+          refres = refa/refb
+          res = a/b
+        check res == toCppComplex(refres)
+
+    test "abs":
       var
         a = initCppComplex[float64](141.571, 124.412)
-        b = initCppComplex[float64](22.17843, 0.523)
         refa = toComplex(a)
-        refb = toComplex(b)
-        refres = refa+refb
-        res = a+b
-      check res == toCppComplex(refres)
-    block:
+
+      check abs(a) == abs(refa)
+
+    test "norm":
       var
         a = initCppComplex[float64](141.571, 124.412)
-        b = initCppComplex[float64](22.17843, 0.523)
         refa = toComplex(a)
-        refb = toComplex(b)
-        refres = refa-refb
-        res = a-b
-      check res == toCppComplex(refres)
-    block:
+
+      check norm(a) == abs2(refa)
+
+    test "conj":
       var
         a = initCppComplex[float64](141.571, 124.412)
-        b = initCppComplex[float64](22.17843, 0.523)
         refa = toComplex(a)
-        refb = toComplex(b)
-        refres = refa*refb
-        res = a*b
-      check res == toCppComplex(refres)
-    block:
+
+      check conj(a) == conjugate(refa).toCppComplex()
+
+    test "polar":
       var
         a = initCppComplex[float64](141.571, 124.412)
-        b = initCppComplex[float64](22.17843, 0.523)
         refa = toComplex(a)
-        refb = toComplex(b)
-        refres = refa/refb
-        res = a/b
-      check res == toCppComplex(refres)
+        # Use Nim to calculate polar coordinate of refa
+        polcoord = polar(refa)
+        b = polar(polcoord.r, polcoord.phi)
 
-  test "abs":
-    var
-      a = initCppComplex[float64](141.571, 124.412)
-      refa = toComplex(a)
+      check (a - b).real < 1e-12
+      check (a - b).imag < 1e-12
 
-    check abs(a) == abs(refa)
+    test "display":
+      var a = initCppComplex[float64](141.571, 124.412)
+      check `$`(a) == "(141.571, 124.412)"
 
-  test "norm":
-    var
-      a = initCppComplex[float64](141.571, 124.412)
-      refa = toComplex(a)
-
-    check norm(a) == abs2(refa)
-
-  test "conj":
-    var
-      a = initCppComplex[float64](141.571, 124.412)
-      refa = toComplex(a)
-
-    check conj(a) == conjugate(refa).toCppComplex()
-
-  test "polar":
-    var
-      a = initCppComplex[float64](141.571, 124.412)
-      refa = toComplex(a)
-      # Use Nim to calculate polar coordinate of refa
-      polcoord = polar(refa)
-      b = polar(polcoord.r, polcoord.phi)
-
-    check (a - b).real < 1e-12
-    check (a - b).imag < 1e-12
-
-  test "display":
-    var a = initCppComplex[float64](141.571, 124.412)
-    check `$`(a) == "(141.571, 124.412)"
+test()

--- a/tests/tpair.nim
+++ b/tests/tpair.nim
@@ -3,109 +3,111 @@ import std/unittest
 import cppstl/std_pair
 import cppstl/std_string
 
-suite "CppPair":
-  test "constructors and field access":
-    block:
-      var p = initCppPair[CppString, cint]()
-      check p.first == initCppString()
-      check p.second == 0.cint
+proc test = 
+  suite "CppPair":
+    test "constructors and field access":
+      block:
+        var p = initCppPair[CppString, cint]()
+        check p.first == initCppString()
+        check p.second == 0.cint
 
-    block:
-      var p1 = initCppPair(initCppString("hello"), 42.cint)
-      check p1.first == initCppString("hello")
-      check p1.second == 42.cint
+      block:
+        var p1 = initCppPair(initCppString("hello"), 42.cint)
+        check p1.first == initCppString("hello")
+        check p1.second == 42.cint
 
-      var p2 = initCppPair(p1)
+        var p2 = initCppPair(p1)
+        check p2.first == initCppString("hello")
+        check p2.second == 42.cint
+
+    test "member functions":
+      var
+        p1 = initCppPair(initCppString("hello"), 42.cint)
+        p2 = initCppPair(initCppString("world"), 100.cint)
+      p1.swap(p2)
+      check p1.first == initCppString("world")
+      check p1.second == 100.cint
       check p2.first == initCppString("hello")
       check p2.second == 42.cint
 
-  test "member functions":
-    var
-      p1 = initCppPair(initCppString("hello"), 42.cint)
-      p2 = initCppPair(initCppString("world"), 100.cint)
-    p1.swap(p2)
-    check p1.first == initCppString("world")
-    check p1.second == 100.cint
-    check p2.first == initCppString("hello")
-    check p2.second == 42.cint
+    test "comparison operators":
+      block:
+        var
+          p1 = initCppPair(initCppString("hello"), 42.cint)
+          p2 = initCppPair(initCppString("hello"), 50.cint)
+          p3 = initCppPair(initCppString("0hello"), 50.cint)
+          p4 = initCppPair(initCppString("zhello"), 50.cint)
 
-  test "comparison operators":
-    block:
-      var
-        p1 = initCppPair(initCppString("hello"), 42.cint)
-        p2 = initCppPair(initCppString("hello"), 50.cint)
-        p3 = initCppPair(initCppString("0hello"), 50.cint)
-        p4 = initCppPair(initCppString("zhello"), 50.cint)
+        check not (p1 == p2)
+        check not (p2 == p1)
+        check p1 != p2
+        check p2 != p1
+        check p1 < p2
+        check not (p2 < p1)
+        check p1 <= p2
+        check not (p2 <= p1)
+        check not (p1 > p2)
+        check p2 > p1
+        check not (p1 >= p2)
+        check p2 >= p1
+        check p3 < p1
+        check not (p3 >= p1)
+        check p4 > p1
+        check not (p4 <= p1)
 
-      check not (p1 == p2)
-      check not (p2 == p1)
-      check p1 != p2
-      check p2 != p1
-      check p1 < p2
-      check not (p2 < p1)
-      check p1 <= p2
-      check not (p2 <= p1)
-      check not (p1 > p2)
-      check p2 > p1
-      check not (p1 >= p2)
-      check p2 >= p1
-      check p3 < p1
-      check not (p3 >= p1)
-      check p4 > p1
-      check not (p4 <= p1)
+      block:
+        var
+          p1 = initCppPair("hello", 42.cint)
+          p2 = initCppPair("hello", 50.cint)
+          p3 = initCppPair("0hello", 50.cint)
+          p4 = initCppPair("zhello", 50.cint)
 
-    block:
-      var
-        p1 = initCppPair("hello", 42.cint)
-        p2 = initCppPair("hello", 50.cint)
-        p3 = initCppPair("0hello", 50.cint)
-        p4 = initCppPair("zhello", 50.cint)
-
-      check not (p1 == p2)
-      check not (p2 == p1)
-      check p1 != p2
-      check p2 != p1
-      check p1 < p2
-      check not (p2 < p1)
-      check p1 <= p2
-      check not (p2 <= p1)
-      check not (p1 > p2)
-      check p2 > p1
-      check not (p1 >= p2)
-      check p2 >= p1
-      check p3 < p1
-      check not (p3 >= p1)
-      check p4 > p1
-      check not (p4 <= p1)
+        check not (p1 == p2)
+        check not (p2 == p1)
+        check p1 != p2
+        check p2 != p1
+        check p1 < p2
+        check not (p2 < p1)
+        check p1 <= p2
+        check not (p2 <= p1)
+        check not (p1 > p2)
+        check p2 > p1
+        check not (p1 >= p2)
+        check p2 >= p1
+        check p3 < p1
+        check not (p3 >= p1)
+        check p4 > p1
+        check not (p4 <= p1)
 
 
-  test "other non-member functions":
-    block:
+    test "other non-member functions":
+      block:
+        var p = initCppPair(initCppString("hello"), 42.cint)
+        check get(CppString, p) == initCppString("hello")
+        check get(cint, p) == 42.cint
+        check not compiles(get(cfloat, p))
+
+      block:
+        var p = initCppPair(100.cint, 42.cint)
+        check not compiles(get(cint, p))
+
+      block:
+        var p = initCppPair(initCppString("hello"), 42.cint)
+        check get(0, p) == initCppString("hello")
+        check get(1, p) == 42.cint
+        check not compiles(get(2, p))
+
+    test "$":
       var p = initCppPair(initCppString("hello"), 42.cint)
-      check get(CppString, p) == initCppString("hello")
-      check get(cint, p) == 42.cint
-      check not compiles(get(cfloat, p))
+      check $p == "CppPair(first: hello, second: 42)"
 
-    block:
-      var p = initCppPair(100.cint, 42.cint)
-      check not compiles(get(cint, p))
+    test "toTuple and back":
+      let 
+        f = "Hello world"
+        s = 144
+      var pair : CppPair[string,int] = makePair(f, s)
+      var tup = pair.toTuple()
+      check tup == (first: f, second: s)
+      check makePair(tup) == pair
 
-    block:
-      var p = initCppPair(initCppString("hello"), 42.cint)
-      check get(0, p) == initCppString("hello")
-      check get(1, p) == 42.cint
-      check not compiles(get(2, p))
-
-  test "$":
-    var p = initCppPair(initCppString("hello"), 42.cint)
-    check $p == "CppPair(first: hello, second: 42)"
-
-  test "toTuple and back":
-    let 
-      f = "Hello world"
-      s = 144
-    var pair : CppPair[string,int] = makePair(f, s)
-    var tup = pair.toTuple()
-    check tup == (first: f, second: s)
-    check makePair(tup) == pair
-
+test()

--- a/tests/tstring.nim
+++ b/tests/tstring.nim
@@ -2,415 +2,417 @@
 import unittest
 import cppstl/std_string
 
-suite "CppString":
-  test "constructors and iterators":
-    var s = initCppString()
-    check s.empty
-    check s.length == 0
-    check s == "".cstring
+proc test = 
+  suite "CppString":
+    test "constructors and iterators":
+      var s = initCppString()
+      check s.empty
+      check s.length == 0
+      check s == "".cstring
 
-    s = initCppString("hello nim")
-    check s == "hello nim".cstring
-    check $s == "hello nim".cstring
+      s = initCppString("hello nim")
+      check s == "hello nim".cstring
+      check $s == "hello nim".cstring
 
-    s = initCppString("hello nim", 5)
-    check s == "hello".cstring
+      s = initCppString("hello nim", 5)
+      check s == "hello".cstring
 
-    var s1: CppString = initCppString("hello")
-    check s1 == s
+      var s1: CppString = initCppString("hello")
+      check s1 == s
 
-    s1 = initCppString(s)
-    check s1 == s
+      s1 = initCppString(s)
+      check s1 == s
 
-    s1 = initCppString(s, 3)
-    check s1 == "lo".cstring
+      s1 = initCppString(s, 3)
+      check s1 == "lo".cstring
 
-    s1 = initCppString(s, 0, 4)
-    check s1 == "hell".cstring
+      s1 = initCppString(s, 0, 4)
+      check s1 == "hell".cstring
 
-    s1 = initCppString(s.begin, s.`end`)
-    check s1 == s
+      s1 = initCppString(s.begin, s.`end`)
+      check s1 == s
 
-    s1 = initCppString(s.begin, s.begin+4)
-    check s1 == "hell".cstring
+      s1 = initCppString(s.begin, s.begin+4)
+      check s1 == "hell".cstring
 
-    s1 = initCppString(s.cbegin, s.cbegin+4)
-    check s1 == "hell".cstring
-
-    s1 = initCppString(s.rbegin, s.rend)
-    check s1 == "olleh".cstring
-
-    s1 = initCppString(s.crbegin, s.crend)
-    check s1 == "olleh".cstring
-
-  test "capacity & size":
-    var s: CppString = initCppString "Hello Nim!"
-
-    check s.size == s.length
-    check s.maxSize > s.size
-
-    s.resize 5
-
-    check s == "Hello".cstring
-    check s.capacity >= s.size
-
-    let oldCap = s.capacity
-    s.reserve(2*oldCap)
-
-    check s.capacity == 2*oldCap
-
-    s.clear
-
-    check s.empty
-    check s == "".cstring
-
-    s = initCppString("Hello")
-    s.reserve(s.capacity*2)
-    s.shrinkToFit
-
-    # check s.length == s.capacity # implementation dependent.
-      # Does not allways hold
-
-  test "accessors":
-    var s: CppString = initCppString("Hello Nim!")
-    check s[1] == 'e'
-    check s.at(1) == 'e'
-    check s.front == 'H'
-    check s.back == '!'
-
-    s[1] = 'o'
-
-    check s[1] == 'o'
-
-    s.at(1) = 'e'
-    s.front() = 'h'
-    s.back() = '?'
-
-    check s == "hello Nim?".cstring
-
-    when compileOption("boundChecks"):
-      expect(IndexDefect):
-        discard s[100]
-      expect(OutOfRangeException):
-        discard s.at(100)
-
-  test "test string modifiers":
-    var s: CppString = toCppString("Hello")
-    var s2 = toCppString(" Nim!")
-    s += s2
-
-    check s == "Hello Nim!".cstring
-    s += " Welcome!".cstring
-    check s == "Hello Nim! Welcome!".cstring
-    s += '!'
-    check s == "Hello Nim! Welcome!!".cstring
-
-    s = initCppString("Hello")
-    s.append s2
-    check s == "Hello Nim!".cstring
-    s.append " Welcome!".cstring
-    check s == "Hello Nim! Welcome!".cstring
-    s.append(1, '!')
-    check s == "Hello Nim! Welcome!!".cstring
-    s.append(3, '!')
-    check s == "Hello Nim! Welcome!!!!!".cstring
-
-    s2 = initCppString "!!! :)"
-    s.append(s2, 3, 3)
-    check s == "Hello Nim! Welcome!!!!! :)".cstring
-    s.append(" :)...........".cstring, 4)
-    check s == "Hello Nim! Welcome!!!!! :) :).".cstring
-
-    s2 = initCppString "I say Bye!"
-    s.append(s2.cbegin+5, s2.cend)
-    check s == "Hello Nim! Welcome!!!!! :) :). Bye!".cstring
-    s.pushBack '!'
-    check s == "Hello Nim! Welcome!!!!! :) :). Bye!!".cstring
-
-    s = initCppString ""
-    s2 = initCppString "Hello"
-    s.assign(s2)
-    check s == s2
-    s.assign(s2, 1, 3)
-    check s == "ell".cstring
-    s.assign("hi".cstring)
-    check s == "hi".cstring
-    s.assign("hello".cstring, 4)
-    check s == "hell".cstring
-    s.assign(3, '6')
-    check s == "666".cstring
-
-    s = initCppString "H!!!"
-    s2 = initCppString "ello "
-    s.insert(1, s2)
-    check s == "Hello !!!".cstring
-
-    s = initCppString "H!!!"
-    s2 = initCppString "Hello !!!"
-    s.insert(1, s2, 1, 5)
-    check s == "Hello !!!".cstring
-
-    s = initCppString "H!!!"
-    s.insert(1, "ello ".cstring)
-    check s == "Hello !!!".cstring
-
-    s = initCppString "H!!!"
-    s.insert(1, "ello ???".cstring, 5)
-    check s == "Hello !!!".cstring
-
-    s = initCppString "Heo !!!"
-    s.insert(2, 2, 'l')
-    check s == "Hello !!!".cstring
-
-    s = initCppString "Heo !!!"
-    s.insert(s.begin+2, 2, 'l')
-    check s == "Hello !!!".cstring
-
-    s = initCppString "Hllo !!!"
-    s.insert(s.begin+1, 'e')
-    check s == "Hello !!!".cstring
-
-    s = initCppString "H!!!"
-    s2 = initCppString "Hello !!!"
-    s.insert(s.begin+1, s2.cbegin+1, s2.cend-3)
-    check s == "Hello !!!".cstring
-
-    s = initCppString "Hello"
-    s.erase()
-    check s.empty
-
-    s = initCppString "Hello"
-    s.erase(1)
-    check s == "H".cstring
-
-    s = initCppString "Hello"
-    s.erase(1, 3)
-    check s == "Ho".cstring
-
-    s = initCppString "Hello"
-    s.erase(s.begin+1)
-    check s == "Hllo".cstring
-
-    s = initCppString "Hello"
-    s.erase(s.begin+1, s.`end`)
-    check s == "H".cstring
-
-    s = initCppString "HELLO !"
-    s2 = initCppString "ello"
-    s.replace(1, 4, s2)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s2 = initCppString "ello"
-    s.replace(s.cbegin+1, s.cend-2, s2)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s2 = initCppString "hhhello there"
-    s.replace(1, 4, s2, 3, 4)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s.replace(1, 4, "ello".cstring)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s.replace(s.cbegin+1, s.cend-2, "ello".cstring)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s.replace(1, 4, "ello....".cstring, 4)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s.replace(s.cbegin+1, s.cend-2, "ello....".cstring, 4)
-    check s == "Hello !".cstring
-
-    s = initCppString "Hejjo !"
-    s.replace(2, 2, 4, 'l')
-    check s == "Hellllo !".cstring
-
-    s = initCppString "Hejjo !"
-    s.replace(s.cbegin+2, s.cbegin+4, 4, 'l')
-    check s == "Hellllo !".cstring
-
-    s = initCppString "HELLO !"
-    s2 = initCppString "hello"
-    s.replace(s.cbegin+1, s.cend-2, s2.cbegin+1, s2.cend)
-    check s == "Hello !".cstring
-
-    s = initCppString "HELLO !"
-    s2 = initCppString "hello"
-    s.swap s2
-    check s == "hello".cstring
-    s.popBack
-    check s == "hell".cstring
-
-  test "test string operations":
-    var s: CppString = initCppString "Hello Nim!"
-
-    check s.cStr == "Hello Nim!".cstring
-    check s.data[] == 'H'
-
-    var s2: CppString = initCppString "Hello"
-    var cstr = newSeq[cchar](4)
-    discard s2.copy(addr cstr[0], 3, 2)
-
-    check cast[cstring](addr cstr[0]) == "llo"
-
-    s = initCppString "hello hello"
-    s2 = initCppString "ll"
-
-    check s.find(s2) == 2
-    check s.find(s2, 5) == 8
-    check s.find("ll".cstring) == 2
-    check s.find("ll".cstring, 5) == 8
-    check s.find("ll0".cstring, 5, 3) == std_npos
-    check s.find("ll0".cstring, 5, 2) == 8
-    check s.find('e') == 1
-    check s.find('e', 3) == 7
-
-    check s.rfind(s2) == 8
-    check s.rfind(s2, 5) == 2
-    check s.rfind("ll".cstring) == 8
-    check s.rfind("ll".cstring, 5) == 2
-    check s.rfind("ll0".cstring, 5, 3) == std_npos
-    check s.rfind("ll0".cstring, 5, 2) == 2
-    check s.rfind('e') == 7
-    check s.rfind('e', 3) == 1
-
-    s = initCppString "Please, replace the vowels in this sentence by asterisks."
-    s2 = initCppString "aeiou"
-    var found = s.findFirstOf(s2);
-    while found != std_npos:
-      s[found] = '*'
-      found = s.findFirstOf(s2, found+1)
-
-    check s == "Pl**s*, r*pl*c* th* v*w*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
-
-    s = initCppString "Please, replace the vowels in this sentence by asterisks."
-    found = s.findFirstOf("aeiou");
-    while found != std_npos:
-      s[found] = '*'
-      found = s.findFirstOf("aeiou", found+1)
-
-    check s == "Pl**s*, r*pl*c* th* v*w*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
-
-    s = initCppString "Please, replace the vowels in this sentence by asterisks."
-    found = s.findFirstOf("aeiou", 0, 3);
-    while found != std_npos:
-      s[found] = '*'
-      found = s.findFirstOf("aeiou", found+1, 3)
-
-    check s == "Pl**s*, r*pl*c* th* vow*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
-    check s.findFirstOf('l', 3) == 11
-
-    s = initCppString "/usr/bin/man"
-    s2 = initCppString "/\\"
-
-    found = s.findLastOf(s2)
-    check s.substr(found+1) == "man".cstring
-    found = s.findLastOf(s2, found-1)
-    check s.substr(found+1) == "bin/man".cstring
-    found = s.findLastOf("/\\")
-    check s.substr(found+1) == "man".cstring
-    found = s.findLastOf("/\\", found-1)
-    check s.substr(found+1) == "bin/man".cstring
-    found = s.findLastOf("/\\lll", std_npos, 3)
-    check s.substr(found+1) == "man".cstring
-    found = s.findLastOf("/\\", found-1, 3)
-    check s.substr(found+1) == "bin/man".cstring
-    found = s.findLastOf('m')
-    check s.substr(found) == "man".cstring
-    found = s.findLastOf('b', found-1)
-    check s.substr(found) == "bin/man".cstring
-
-    s = initCppString "1293a456b7"
-    s2 = initCppString "123456789"
-
-    check s.findFirstNotOf(s2) == 4
-    check s.findFirstNotOf(s2, 5) == 8
-    check s.findFirstNotOf("123456789".cstring) == 4
-    check s.findFirstNotOf("123456789".cstring, 5) == 8
-    check s.findFirstNotOf("123456789".cstring, 0, 3) == 2
-    check s.findFirstNotOf("123456789".cstring, 4, 3) == 4
-    check s.findFirstNotOf('1') == 1
-    check s.findFirstNotOf('1', 1) == 1
-
-    check s.findLastNotOf(s2) == 8
-    check s.findLastNotOf(s2, 5) == 4
-    check s.findLastNotOf("123456789".cstring) == 8
-    check s.findLastNotOf("123456789".cstring, 5) == 4
-    check s.findLastNotOf("123456789".cstring, std_npos, 3) == 9
-    check s.findLastNotOf("123456789".cstring, 4, 3) == 4
-    check s.findLastNotOf('1') == 9
-    check s.findLastNotOf('1', 1) == 1
-
-    s = initCppString "green apple"
-    s2 = initCppString "red apple"
-
-    check s.compare(s2) != 0
-    check s.compare("red apple".cstring) != 0
-    check s.compare(0, s.length, s2) != 0
-    check s.compare(0, s.length, "red apple".cstring) != 0
-    check s.compare(6, 5, "apple".cstring) == 0
-    check s.compare(6, 5, "red apple".cstring, 4, 5) == 0
-    check s.compare(6, 5, s2, 4, 5) == 0
-
-  test "test string non-member function overloads":
-    var s1: CppString = initCppString "Hello "
-    var s2: CppString = initCppString "Nim"
-
-    check s1+s2 == "Hello Nim".cstring
-    check s1+"Nim".cstring == "Hello Nim".cstring
-    check "Hello ".cstring()+s2 == "Hello Nim".cstring
-    check s1+'!' == "Hello !".cstring
-    check '!'+s1+'!' == "!Hello !".cstring
-
-    s1 += s2
-
-    check s1 == "Hello Nim".cstring
-
-    s1 = initCppString "alpha"
-    s2 = initCppString "beta"
-
-    check s1 != s2
-    check s1 != "beta".cstring
-    check "alpha".cstring != s2
-    check not (s1 == s2)
-    check not (s1 == "beta".cstring)
-    check not ("alpha".cstring == s2)
-    check s1 < s2
-    check not (s1 > s2)
-    check s1 > "aaaaaaaaaaaaa".cstring
-    check s1 <= s2
-    check not (s1 >= s2)
-    check s1 >= "aaaaaaaaaaaaa".cstring
-
-  test "Nim iterators":
-    let s1 = toCppString("123456789")
-    block:
+      s1 = initCppString(s.cbegin, s.cbegin+4)
+      check s1 == "hell".cstring
+
+      s1 = initCppString(s.rbegin, s.rend)
+      check s1 == "olleh".cstring
+
+      s1 = initCppString(s.crbegin, s.crend)
+      check s1 == "olleh".cstring
+
+    test "capacity & size":
+      var s: CppString = initCppString "Hello Nim!"
+
+      check s.size == s.length
+      check s.maxSize > s.size
+
+      s.resize 5
+
+      check s == "Hello".cstring
+      check s.capacity >= s.size
+
+      let oldCap = s.capacity
+      s.reserve(2*oldCap)
+
+      check s.capacity == 2*oldCap
+
+      s.clear
+
+      check s.empty
+      check s == "".cstring
+
+      s = initCppString("Hello")
+      s.reserve(s.capacity*2)
+      s.shrinkToFit
+
+      # check s.length == s.capacity # implementation dependent.
+        # Does not allways hold
+
+    test "accessors":
+      var s: CppString = initCppString("Hello Nim!")
+      check s[1] == 'e'
+      check s.at(1) == 'e'
+      check s.front == 'H'
+      check s.back == '!'
+
+      s[1] = 'o'
+
+      check s[1] == 'o'
+
+      s.at(1) = 'e'
+      s.front() = 'h'
+      s.back() = '?'
+
+      check s == "hello Nim?".cstring
+
+      when compileOption("boundChecks"):
+        expect(IndexDefect):
+          discard s[100]
+        expect(OutOfRangeException):
+          discard s.at(100)
+
+    test "test string modifiers":
+      var s: CppString = toCppString("Hello")
+      var s2 = toCppString(" Nim!")
+      s += s2
+
+      check s == "Hello Nim!".cstring
+      s += " Welcome!".cstring
+      check s == "Hello Nim! Welcome!".cstring
+      s += '!'
+      check s == "Hello Nim! Welcome!!".cstring
+
+      s = initCppString("Hello")
+      s.append s2
+      check s == "Hello Nim!".cstring
+      s.append " Welcome!".cstring
+      check s == "Hello Nim! Welcome!".cstring
+      s.append(1, '!')
+      check s == "Hello Nim! Welcome!!".cstring
+      s.append(3, '!')
+      check s == "Hello Nim! Welcome!!!!!".cstring
+
+      s2 = initCppString "!!! :)"
+      s.append(s2, 3, 3)
+      check s == "Hello Nim! Welcome!!!!! :)".cstring
+      s.append(" :)...........".cstring, 4)
+      check s == "Hello Nim! Welcome!!!!! :) :).".cstring
+
+      s2 = initCppString "I say Bye!"
+      s.append(s2.cbegin+5, s2.cend)
+      check s == "Hello Nim! Welcome!!!!! :) :). Bye!".cstring
+      s.pushBack '!'
+      check s == "Hello Nim! Welcome!!!!! :) :). Bye!!".cstring
+
+      s = initCppString ""
+      s2 = initCppString "Hello"
+      s.assign(s2)
+      check s == s2
+      s.assign(s2, 1, 3)
+      check s == "ell".cstring
+      s.assign("hi".cstring)
+      check s == "hi".cstring
+      s.assign("hello".cstring, 4)
+      check s == "hell".cstring
+      s.assign(3, '6')
+      check s == "666".cstring
+
+      s = initCppString "H!!!"
+      s2 = initCppString "ello "
+      s.insert(1, s2)
+      check s == "Hello !!!".cstring
+
+      s = initCppString "H!!!"
+      s2 = initCppString "Hello !!!"
+      s.insert(1, s2, 1, 5)
+      check s == "Hello !!!".cstring
+
+      s = initCppString "H!!!"
+      s.insert(1, "ello ".cstring)
+      check s == "Hello !!!".cstring
+
+      s = initCppString "H!!!"
+      s.insert(1, "ello ???".cstring, 5)
+      check s == "Hello !!!".cstring
+
+      s = initCppString "Heo !!!"
+      s.insert(2, 2, 'l')
+      check s == "Hello !!!".cstring
+
+      s = initCppString "Heo !!!"
+      s.insert(s.begin+2, 2, 'l')
+      check s == "Hello !!!".cstring
+
+      s = initCppString "Hllo !!!"
+      s.insert(s.begin+1, 'e')
+      check s == "Hello !!!".cstring
+
+      s = initCppString "H!!!"
+      s2 = initCppString "Hello !!!"
+      s.insert(s.begin+1, s2.cbegin+1, s2.cend-3)
+      check s == "Hello !!!".cstring
+
+      s = initCppString "Hello"
+      s.erase()
+      check s.empty
+
+      s = initCppString "Hello"
+      s.erase(1)
+      check s == "H".cstring
+
+      s = initCppString "Hello"
+      s.erase(1, 3)
+      check s == "Ho".cstring
+
+      s = initCppString "Hello"
+      s.erase(s.begin+1)
+      check s == "Hllo".cstring
+
+      s = initCppString "Hello"
+      s.erase(s.begin+1, s.`end`)
+      check s == "H".cstring
+
+      s = initCppString "HELLO !"
+      s2 = initCppString "ello"
+      s.replace(1, 4, s2)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s2 = initCppString "ello"
+      s.replace(s.cbegin+1, s.cend-2, s2)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s2 = initCppString "hhhello there"
+      s.replace(1, 4, s2, 3, 4)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s.replace(1, 4, "ello".cstring)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s.replace(s.cbegin+1, s.cend-2, "ello".cstring)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s.replace(1, 4, "ello....".cstring, 4)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s.replace(s.cbegin+1, s.cend-2, "ello....".cstring, 4)
+      check s == "Hello !".cstring
+
+      s = initCppString "Hejjo !"
+      s.replace(2, 2, 4, 'l')
+      check s == "Hellllo !".cstring
+
+      s = initCppString "Hejjo !"
+      s.replace(s.cbegin+2, s.cbegin+4, 4, 'l')
+      check s == "Hellllo !".cstring
+
+      s = initCppString "HELLO !"
+      s2 = initCppString "hello"
+      s.replace(s.cbegin+1, s.cend-2, s2.cbegin+1, s2.cend)
+      check s == "Hello !".cstring
+
+      s = initCppString "HELLO !"
+      s2 = initCppString "hello"
+      s.swap s2
+      check s == "hello".cstring
+      s.popBack
+      check s == "hell".cstring
+
+    test "test string operations":
+      var s: CppString = initCppString "Hello Nim!"
+
+      check s.cStr == "Hello Nim!".cstring
+      check s.data[] == 'H'
+
+      var s2: CppString = initCppString "Hello"
+      var cstr = newSeq[cchar](4)
+      discard s2.copy(addr cstr[0], 3, 2)
+
+      check cast[cstring](addr cstr[0]) == "llo"
+
+      s = initCppString "hello hello"
+      s2 = initCppString "ll"
+
+      check s.find(s2) == 2
+      check s.find(s2, 5) == 8
+      check s.find("ll".cstring) == 2
+      check s.find("ll".cstring, 5) == 8
+      check s.find("ll0".cstring, 5, 3) == std_npos
+      check s.find("ll0".cstring, 5, 2) == 8
+      check s.find('e') == 1
+      check s.find('e', 3) == 7
+
+      check s.rfind(s2) == 8
+      check s.rfind(s2, 5) == 2
+      check s.rfind("ll".cstring) == 8
+      check s.rfind("ll".cstring, 5) == 2
+      check s.rfind("ll0".cstring, 5, 3) == std_npos
+      check s.rfind("ll0".cstring, 5, 2) == 2
+      check s.rfind('e') == 7
+      check s.rfind('e', 3) == 1
+
+      s = initCppString "Please, replace the vowels in this sentence by asterisks."
+      s2 = initCppString "aeiou"
+      var found = s.findFirstOf(s2);
+      while found != std_npos:
+        s[found] = '*'
+        found = s.findFirstOf(s2, found+1)
+
+      check s == "Pl**s*, r*pl*c* th* v*w*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
+
+      s = initCppString "Please, replace the vowels in this sentence by asterisks."
+      found = s.findFirstOf("aeiou");
+      while found != std_npos:
+        s[found] = '*'
+        found = s.findFirstOf("aeiou", found+1)
+
+      check s == "Pl**s*, r*pl*c* th* v*w*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
+
+      s = initCppString "Please, replace the vowels in this sentence by asterisks."
+      found = s.findFirstOf("aeiou", 0, 3);
+      while found != std_npos:
+        s[found] = '*'
+        found = s.findFirstOf("aeiou", found+1, 3)
+
+      check s == "Pl**s*, r*pl*c* th* vow*ls *n th*s s*nt*nc* by *st*r*sks.".cstring
+      check s.findFirstOf('l', 3) == 11
+
+      s = initCppString "/usr/bin/man"
+      s2 = initCppString "/\\"
+
+      found = s.findLastOf(s2)
+      check s.substr(found+1) == "man".cstring
+      found = s.findLastOf(s2, found-1)
+      check s.substr(found+1) == "bin/man".cstring
+      found = s.findLastOf("/\\")
+      check s.substr(found+1) == "man".cstring
+      found = s.findLastOf("/\\", found-1)
+      check s.substr(found+1) == "bin/man".cstring
+      found = s.findLastOf("/\\lll", std_npos, 3)
+      check s.substr(found+1) == "man".cstring
+      found = s.findLastOf("/\\", found-1, 3)
+      check s.substr(found+1) == "bin/man".cstring
+      found = s.findLastOf('m')
+      check s.substr(found) == "man".cstring
+      found = s.findLastOf('b', found-1)
+      check s.substr(found) == "bin/man".cstring
+
+      s = initCppString "1293a456b7"
+      s2 = initCppString "123456789"
+
+      check s.findFirstNotOf(s2) == 4
+      check s.findFirstNotOf(s2, 5) == 8
+      check s.findFirstNotOf("123456789".cstring) == 4
+      check s.findFirstNotOf("123456789".cstring, 5) == 8
+      check s.findFirstNotOf("123456789".cstring, 0, 3) == 2
+      check s.findFirstNotOf("123456789".cstring, 4, 3) == 4
+      check s.findFirstNotOf('1') == 1
+      check s.findFirstNotOf('1', 1) == 1
+
+      check s.findLastNotOf(s2) == 8
+      check s.findLastNotOf(s2, 5) == 4
+      check s.findLastNotOf("123456789".cstring) == 8
+      check s.findLastNotOf("123456789".cstring, 5) == 4
+      check s.findLastNotOf("123456789".cstring, std_npos, 3) == 9
+      check s.findLastNotOf("123456789".cstring, 4, 3) == 4
+      check s.findLastNotOf('1') == 9
+      check s.findLastNotOf('1', 1) == 1
+
+      s = initCppString "green apple"
+      s2 = initCppString "red apple"
+
+      check s.compare(s2) != 0
+      check s.compare("red apple".cstring) != 0
+      check s.compare(0, s.length, s2) != 0
+      check s.compare(0, s.length, "red apple".cstring) != 0
+      check s.compare(6, 5, "apple".cstring) == 0
+      check s.compare(6, 5, "red apple".cstring, 4, 5) == 0
+      check s.compare(6, 5, s2, 4, 5) == 0
+
+    test "test string non-member function overloads":
+      var s1: CppString = initCppString "Hello "
+      var s2: CppString = initCppString "Nim"
+
+      check s1+s2 == "Hello Nim".cstring
+      check s1+"Nim".cstring == "Hello Nim".cstring
+      check "Hello ".cstring()+s2 == "Hello Nim".cstring
+      check s1+'!' == "Hello !".cstring
+      check '!'+s1+'!' == "!Hello !".cstring
+
+      s1 += s2
+
+      check s1 == "Hello Nim".cstring
+
+      s1 = initCppString "alpha"
+      s2 = initCppString "beta"
+
+      check s1 != s2
+      check s1 != "beta".cstring
+      check "alpha".cstring != s2
+      check not (s1 == s2)
+      check not (s1 == "beta".cstring)
+      check not ("alpha".cstring == s2)
+      check s1 < s2
+      check not (s1 > s2)
+      check s1 > "aaaaaaaaaaaaa".cstring
+      check s1 <= s2
+      check not (s1 >= s2)
+      check s1 >= "aaaaaaaaaaaaa".cstring
+
+    test "Nim iterators":
+      let s1 = toCppString("123456789")
+      block:
+        var i = 0
+        for c in s1:
+          inc(i)
+          check cchar(i.uint8+uint8('0')) == c
+      block:
+        var i = 0
+        for idx, c in s1.pairs:
+          check idx == i.csize_t
+          inc(i)
+          check cchar(i.uint8+uint8('0')) == c
+
+    test "mutable Nim iterators":
+      var s1 = toCppString("123456789")
+      for c in s1.mitems:
+        c = 'a'
+      check s1.toString == "aaaaaaaaa"
+
       var i = 0
-      for c in s1:
-        inc(i)
-        check cchar(i.uint8+uint8('0')) == c
-    block:
-      var i = 0
-      for idx, c in s1.pairs:
+      for idx, c in s1.mpairs:
         check idx == i.csize_t
         inc(i)
-        check cchar(i.uint8+uint8('0')) == c
+        c = 'b'
+      check s1.toString == "bbbbbbbbb"
 
-  test "mutable Nim iterators":
-    var s1 = toCppString("123456789")
-    for c in s1.mitems:
-      c = 'a'
-    check s1.toString == "aaaaaaaaa"
-
-    var i = 0
-    for idx, c in s1.mpairs:
-      check idx == i.csize_t
-      inc(i)
-      c = 'b'
-    check s1.toString == "bbbbbbbbb"
-
+test()

--- a/tests/tvector.nim
+++ b/tests/tvector.nim
@@ -2,451 +2,457 @@
 import std/[unittest, strformat, sequtils]
 import cppstl/std_vector
 
-suite "CppVector":
-  test "constructor, size/len, empty":
-    var
-      v1 = initCppVector[int]()
-      v2 = initCppVector[int](10)
+proc test = 
+  suite "CppVector":
+    test "constructor, size/len, empty":
+      var
+        v1 = initCppVector[int]()
+        v2 = initCppVector[int](10)
 
-    check v1.size() == 0.csize_t
-    check v2.len() == 10.csize_t
-    check v1.empty() == true
-    check v2.empty() == false
+      check v1.size() == 0.csize_t
+      check v2.len() == 10.csize_t
+      check v1.empty() == true
+      check v2.empty() == false
 
-  test "constructors and iterators":
-    var v = initCppVector[int](3)
+    test "constructors and iterators":
+      var v = initCppVector[int](3)
 
-    check v.size == 3
-    check v[0] == 0
-    check v[1] == 0
-    check v[2] == 0
+      check v.size == 3
+      check v[0] == 0
+      check v[1] == 0
+      check v[2] == 0
 
-    v = initCppVector[int](3, 1)
+      v = initCppVector[int](3, 1)
 
-    check v.size == 3
-    check v[0] == 1
-    check v[1] == 1
-    check v[2] == 1
+      check v.size == 3
+      check v[0] == 1
+      check v[1] == 1
+      check v[2] == 1
 
-    v = initCppVector[int]()
-    v.pushBack(1)
-    v.pushBack(2)
-    v.pushBack(3)
-
-    check v.size == 3
-    check v[0] == 1
-    check v[1] == 2
-    check v[2] == 3
-
-    var v2 = initCppVector(v)
-
-    check v.size == v2.size
-    check v[0] == v2[0]
-    check v[1] == v2[1]
-    check v[2] == v2[2]
-
-    v2 = initCppVector(begin(v), `end`(v))
-
-    check v.size == v2.size
-    check v[0] == v2[0]
-    check v[1] == v2[1]
-    check v[2] == v2[2]
-    check v == v2
-
-    v2 = initCppVector(rBegin(v), rEnd(v))
-
-    check v.size == v2.size
-    check v[0] == v2[2]
-    check v[1] == v2[1]
-    check v[2] == v2[0]
-    check v != v2
-
-    v2 = initCppVector(cBegin(v), cEnd(v))
-
-    check v.size == v2.size
-    check v[0] == v2[0]
-    check v[1] == v2[1]
-    check v[2] == v2[2]
-    check v == v2
-
-    v2 = initCppVector(crBegin(v), crEnd(v))
-
-    check v.size == v2.size
-    check v[0] == v2[2]
-    check v[1] == v2[1]
-    check v[2] == v2[0]
-    check v != v2
-
-  test "capacity":
-    var v = initCppVector[int](3)
-
-    check v.size == 3
-    check v.capacity >= v.size
-    check v.maxSize >= v.size
-    check not v.empty
-
-    let oldCap = v.capacity
-    let oldSz = v.size
-    v.reserve(2*oldCap)
-
-    check oldCap < v.capacity
-    check oldSz == v.size
-
-    v.resize(oldSz+1)
-
-    check oldSz+1 == v.size
-
-    v.shrinkToFit()
-
-    check v.size == v.capacity
-
-  test "element access":
-    var v = initCppVector[int](3)
-
-    check v[0] == 0
-    check v.at(0) == 0
-
-    v[0] = 100
-
-    check v[0] == 100
-    check v.at(0) == 100
-
-    v.at(0) = 1000
-
-    check v[0] == 1000
-    check v.at(0) == 1000
-
-    when compileOption("boundChecks"):
-      expect(IndexDefect):
-        discard v[4]
-      expect(OutOfRangeException):
-        discard v.at(4)
-
-    v = initCppVector[int](5)
-    for i in 0..<v.size:
-      v[i] = i.int
-
-    check v.front == 0
-    check v.back == 4
-
-    v = initCppVector[int](2)
-    v.front() = 10
-    v.back() = 11
-
-    check v[0] == 10
-    check v[1] == 11
-
-    var pdata = v.data
-
-    check pdata[] == 10
-    check cast[ptr int](cast[int](pdata)+1*sizeof(int))[] == 11
-
-  test "push/add, pop, front/first, back/last":
-    var
       v = initCppVector[int]()
-      refSeq = @[100, 300, 400, 500] # This test will create the following Vector
-
-    v.pushBack(100)
-    check v.len() == 1.csize_t
-
-    v.add(200)
-    check v.len() == 2.csize_t
-
-    v.popBack()
-    check v.len() == 1.csize_t
-
-    v.add(300)
-    v.add(400)
-    v.add(500)
-
-    for idx in 0.csize_t ..< v.len():
-      check v[idx] == refSeq[idx]
-
-    check v.len() == 4.csize_t
-
-    check v.first() == 100
-    v.first() = 1
-    check v.front() == 1
-
-    check v.last() == 500
-    v.last() = 5
-    check v.back() == 5
-
-  test "modifiers":
-    var v = initCppVector[int]()
-    for i in 0..<3:
-      v.pushBack i
-
-    for i in 0..<3:
-      check v[i] == i
-
-    v.popBack()
-
-    check v.size == 2
-    for i in 0..<v.size:
-      check v[i] == i.int
-
-    discard v.insert(v.`end`, 2)
-
-    check v.size == 3
-    for i in 0..<3:
-      check v[i] == i.int
-
-    v.popBack()
-
-    discard v.insert(v.cEnd, 2)
-
-    check v.size == 3
-    for i in 0..<3:
-      check v[i] == i
-
-    discard v.insert(v.begin, 100)
-
-    check v.size == 4
-    check v[0] == 100
-
-    discard v.insert(v.begin() + 1, 13)
-
-    check v.size == 5
-    check v[1] == 13
-
-    discard v.insert(v.begin(), 3, 1)
-
-    check v.size == 8
-    for i in 0..<3:
-      check v[i] == 1
-
-    discard v.insert(v.`end`(), v.begin(), v.`end`())
-
-    check v.size == 16
-    for i in 0..<8:
-      check v[i] == v[i+8]
-
-    discard v.erase(v.begin()+8, v.`end`())
-
-    check v.size == 8
-
-    discard v.erase(v.begin()+2, v.`end`())
-
-    check v.size == 2
-
-    v[0] = 1
-    v[1] = 2
-    discard v.erase(v.begin()+1)
-
-    check v.size == 1
-    check v[0] == 1
-
-    v.pushBack 2
-    discard v.erase(v.begin())
-
-    check v.size == 1
-    check v[0] == 2
-
-    v = initCppVector[int](3, 1)
-    var v1 = initCppVector[int](3, 2)
-
-    for i in 0..<3:
-      check v[i] == 1
-      check v1[i] == 2
-
-    v.swap v1
-
-    for i in 0..<3:
-      check v1[i] == 1
-      check v[i] == 2
-
-    v.clear
-
-    check v.size == 0
-    check v.empty
-
-  test "relational operators":
-    let foo = initCppVector[int](3, 100)
-    let bar = initCppVector[int](2, 200)
-
-    check foo == foo
-    check foo <= foo
-    check foo >= foo
-    check foo != bar
-    check not (foo > bar)
-    check foo < bar
-    check not (foo >= bar)
-    check foo <= bar
-
-    let
-      v1 = @[1, 2, 3].toCppVector()
-
-    block: # ==, <=, >=
-      let
-        v2 = v1
-      check v1 == v2
-      check v1 <= v2
-      check v1 >= v2
-
-    block: # >, >=
-      let
-        v2 = @[1, 2, 4].toCppVector()
-      check v2 > v1
-      check v2 >= v1
-
-    block: # >, unequal CppVector lengths
-      let
-        v2 = @[1, 2, 4].toCppVector()
-        v3 = @[1, 2, 3, 0].toCppVector()
-      check v3 > v1
-      check v2 > v3
-
-    block: # <, <=
-      let
-        v2 = @[1, 2, 4].toCppVector()
-      check v1 < v2
-      check v1 <= v2
-
-    block: # <, unequal CppVector lengths
-      let
-        v2 = @[1, 2, 4].toCppVector()
-        v3 = @[1, 2, 3, 0].toCppVector()
-      check v1 < v3
-      check v3 < v2
-
-  test "display, $":
-    block:
-      var v = initCppVector[int]()
-      check $v == "[]"
       v.pushBack(1)
       v.pushBack(2)
       v.pushBack(3)
-      check $v == "[1, 2, 3]"
-      check (v.size() == 3)
 
-    block:
-      var v = initCppVector[string]()
-      v.add "hi"
-      v.add "there"
-      v.add "bye"
-      check $v == "[hi, there, bye]"
+      check v.size == 3
+      check v[0] == 1
+      check v[1] == 2
+      check v[2] == 3
 
-    block:
-      var v = initCppVector[float](5, 0.0'f64)
-      check $v == "[0.0, 0.0, 0.0, 0.0, 0.0]"
-      check v.size() == 5
+      var v2 = initCppVector(v)
 
-  test "iterators":
-    var
-      refSeq = @["hi", "there", "bye"]
-      v = toCppVector(refSeq)
+      check v.size == v2.size
+      check v[0] == v2[0]
+      check v[1] == v2[1]
+      check v[2] == v2[2]
+      check v <= v2
 
-    var i = 0
-    for elem in v:
-      check elem == refSeq[i]
-      inc(i)
+      v2 = initCppVector(begin(v), `end`(v))
 
-    for idx, elem in v:
-      check elem == refSeq[idx]
+      check v.size == v2.size
+      check v[0] == v2[0]
+      check v[1] == v2[1]
+      check v[2] == v2[2]
+      check v == v2
 
-  test "converting to/from a CppVector/mutable sequence":
-    var
-      s = @[1.1, 2.2, 3.3, 4.4, 5.5]
-      v: CppVector[float]
+      v2 = initCppVector(rBegin(v), rEnd(v))
 
-    v = s.toCppVector()
-    check v.toSeq() == s
+      check v.size == v2.size
+      check v[0] == v2[2]
+      check v[1] == v2[1]
+      check v[2] == v2[0]
+      check v != v2
+      check v < v2
+      check v <= v2
 
-  test "converting from an immutable sequence":
-    let
-      s = @[1.1, 2.2, 3.3, 4.4, 5.5]
-    var
-      v: CppVector[float]
+      v2 = initCppVector(cBegin(v), cEnd(v))
 
-    v = s.toCppVector()
-    check v.toSeq() == s
+      check v.size == v2.size
+      check v[0] == v2[0]
+      check v[1] == v2[1]
+      check v[2] == v2[2]
+      check v == v2
 
-  test "converting array -> CppVector -> sequence":
-    let
-      a = [1.1, 2.2, 3.3, 4.4, 5.5]
-      v = a.toCppVector()
-      s = a.toSeq()
+      v2 = initCppVector(crBegin(v), crEnd(v))
 
-    check v.toSeq() == s
+      check v.size == v2.size
+      check v[0] == v2[2]
+      check v[1] == v2[1]
+      check v[2] == v2[0]
+      check v != v2
 
-  test "assign":
-    var
-      v: CppVector[char]
+    test "capacity":
+      var v = initCppVector[int](3)
 
-    check v.len() == 0
+      check v.size == 3
+      check v.capacity >= v.size
+      check v.maxSize >= v.size
+      check not v.empty
 
-    v.assign(4, '.')
-    check v.toSeq() == @['.', '.', '.', '.']
+      let oldCap = v.capacity
+      let oldSz = v.size
+      v.reserve(2*oldCap)
 
-    v.assign(2, 'a')
-    check v.toSeq() == @['a', 'a']
+      check oldCap < v.capacity
+      check oldSz == v.size
 
-  test "set an element value `[]=`":
-    var
+      v.resize(oldSz+1)
+
+      check oldSz+1 == v.size
+
+      v.shrinkToFit()
+
+      check v.size == v.capacity
+
+    test "element access":
+      var v = initCppVector[int](3)
+
+      check v[0] == 0
+      check v.at(0) == 0
+
+      v[0] = 100
+
+      check v[0] == 100
+      check v.at(0) == 100
+
+      v.at(0) = 1000
+
+      check v[0] == 1000
+      check v.at(0) == 1000
+
+      when compileOption("boundChecks"):
+        expect(IndexDefect):
+          discard v[4]
+        expect(OutOfRangeException):
+          discard v.at(4)
+
       v = initCppVector[int](5)
+      for i in 0..<v.size:
+        v[i] = i.int
 
-    v[1] = 100
-    v[3] = 300
-    check v.toSeq() == @[0, 100, 0, 300, 0]
+      check v.front == 0
+      check v.back == 4
 
-  test "(c)begin, (c)end, insert":
-    var
+      v = initCppVector[int](2)
+      v.front() = 10
+      v.back() = 11
+
+      check v[0] == 10
+      check v[1] == 11
+
+      var pdata = v.data
+
+      check pdata[] == 10
+      check cast[ptr int](cast[int](pdata)+1*sizeof(int))[] == 11
+
+    test "push/add, pop, front/first, back/last":
+      var
+        v = initCppVector[int]()
+        refSeq = @[100, 300, 400, 500] # This test will create the following Vector
+
+      v.pushBack(100)
+      check v.len() == 1.csize_t
+
+      v.add(200)
+      check v.len() == 2.csize_t
+
+      v.popBack()
+      check v.len() == 1.csize_t
+
+      v.add(300)
+      v.add(400)
+      v.add(500)
+
+      for idx in 0.csize_t ..< v.len():
+        check v[idx] == refSeq[idx]
+
+      check v.len() == 4.csize_t
+
+      check v.first() == 100
+      v.first() = 1
+      check v.front() == 1
+
+      check v.last() == 500
+      v.last() = 5
+      check v.back() == 5
+
+    test "modifiers":
+      var v = initCppVector[int]()
+      for i in 0..<3:
+        v.pushBack i
+
+      for i in 0..<3:
+        check v[i] == i
+
+      v.popBack()
+
+      check v.size == 2
+      for i in 0..<v.size:
+        check v[i] == i.int
+
+      discard v.insert(v.`end`, 2)
+
+      check v.size == 3
+      for i in 0..<3:
+        check v[i] == i.int
+
+      v.popBack()
+
+      discard v.insert(v.cEnd, 2)
+
+      check v.size == 3
+      for i in 0..<3:
+        check v[i] == i
+
+      discard v.insert(v.begin, 100)
+
+      check v.size == 4
+      check v[0] == 100
+
+      discard v.insert(v.begin() + 1, 13)
+
+      check v.size == 5
+      check v[1] == 13
+
+      discard v.insert(v.begin(), 3, 1)
+
+      check v.size == 8
+      for i in 0..<3:
+        check v[i] == 1
+
+      discard v.insert(v.`end`(), v.begin(), v.`end`())
+
+      check v.size == 16
+      for i in 0..<8:
+        check v[i] == v[i+8]
+
+      discard v.erase(v.begin()+8, v.`end`())
+
+      check v.size == 8
+
+      discard v.erase(v.begin()+2, v.`end`())
+
+      check v.size == 2
+
+      v[0] = 1
+      v[1] = 2
+      discard v.erase(v.begin()+1)
+
+      check v.size == 1
+      check v[0] == 1
+
+      v.pushBack 2
+      discard v.erase(v.begin())
+
+      check v.size == 1
+      check v[0] == 2
+
+      v = initCppVector[int](3, 1)
+      var v1 = initCppVector[int](3, 2)
+
+      for i in 0..<3:
+        check v[i] == 1
+        check v1[i] == 2
+
+      v.swap v1
+
+      for i in 0..<3:
+        check v1[i] == 1
+        check v[i] == 2
+
+      v.clear
+
+      check v.size == 0
+      check v.empty
+
+    test "relational operators":
+      let foo = initCppVector[int](3, 100)
+      let bar = initCppVector[int](2, 200)
+
+      check foo == foo
+      check foo <= foo
+      check foo >= foo
+      check foo != bar
+      check not (foo > bar)
+      check foo < bar
+      check not (foo >= bar)
+      check foo <= bar
+
+      let
+        v1 = @[1, 2, 3].toCppVector()
+
+      block: # ==, <=, >=
+        let
+          v2 = v1
+        check v1 == v2
+        check v1 <= v2
+        check v1 >= v2
+
+      block: # >, >=
+        let
+          v2 = @[1, 2, 4].toCppVector()
+        check v2 > v1
+        check v2 >= v1
+
+      block: # >, unequal CppVector lengths
+        let
+          v2 = @[1, 2, 4].toCppVector()
+          v3 = @[1, 2, 3, 0].toCppVector()
+        check v3 > v1
+        check v2 > v3
+
+      block: # <, <=
+        let
+          v2 = @[1, 2, 4].toCppVector()
+        check v1 < v2
+        check v1 <= v2
+
+      block: # <, unequal CppVector lengths
+        let
+          v2 = @[1, 2, 4].toCppVector()
+          v3 = @[1, 2, 3, 0].toCppVector()
+        check v1 < v3
+        check v3 < v2
+
+    test "display, $":
+      block:
+        var v = initCppVector[int]()
+        check $v == "[]"
+        v.pushBack(1)
+        v.pushBack(2)
+        v.pushBack(3)
+        check $v == "[1, 2, 3]"
+        check (v.size() == 3)
+
+      block:
+        var v = initCppVector[string]()
+        v.add "hi"
+        v.add "there"
+        v.add "bye"
+        check $v == "[hi, there, bye]"
+
+      block:
+        var v = initCppVector[float](5, 0.0'f64)
+        check $v == "[0.0, 0.0, 0.0, 0.0, 0.0]"
+        check v.size() == 5
+
+    test "iterators":
+      var
+        refSeq = @["hi", "there", "bye"]
+        v = toCppVector(refSeq)
+
+      var i = 0
+      for elem in v:
+        check elem == refSeq[i]
+        inc(i)
+
+      for idx, elem in v:
+        check elem == refSeq[idx]
+
+    test "converting to/from a CppVector/mutable sequence":
+      var
+        s = @[1.1, 2.2, 3.3, 4.4, 5.5]
+        v: CppVector[float]
+
+      v = s.toCppVector()
+      check v.toSeq() == s
+
+    test "converting from an immutable sequence":
+      let
+        s = @[1.1, 2.2, 3.3, 4.4, 5.5]
+      var
+        v: CppVector[float]
+
+      v = s.toCppVector()
+      check v.toSeq() == s
+
+    test "converting array -> CppVector -> sequence":
+      let
+        a = [1.1, 2.2, 3.3, 4.4, 5.5]
+        v = a.toCppVector()
+        s = a.toSeq()
+
+      check v.toSeq() == s
+
+    test "assign":
+      var
+        v: CppVector[char]
+
+      check v.len() == 0
+
+      v.assign(4, '.')
+      check v.toSeq() == @['.', '.', '.', '.']
+
+      v.assign(2, 'a')
+      check v.toSeq() == @['a', 'a']
+
+    test "set an element value `[]=`":
+      var
+        v = initCppVector[int](5)
+
+      v[1] = 100
+      v[3] = 300
+      check v.toSeq() == @[0, 100, 0, 300, 0]
+
+    test "(c)begin, (c)end, insert":
+      var
+        v = @[1, 2, 3].toCppVector()
+
+      # insert elem at the beginning
+      discard v.insert(v.cBegin(), 9)
+      check v == @[9, 1, 2, 3].toCppVector()
+
+      # Below, using .begin() instead of .cBegin() also
+      # works.. because of the CppVectorIteratorToCppVectorConstIterator converter.
+      discard v.insert(v.begin(), 10)
+      check v == @[10, 9, 1, 2, 3].toCppVector()
+
+      # insert elem at the end
       v = @[1, 2, 3].toCppVector()
+      discard v.insert(v.cEnd(), 9)
+      check v == @[1, 2, 3, 9].toCppVector()
 
-    # insert elem at the beginning
-    discard v.insert(v.cBegin(), 9)
-    check v == @[9, 1, 2, 3].toCppVector()
+      # Below, using .`end`() instead of .cEnd() also
+      # works.. because of the CppVectorIteratorToCppVectorConstIterator converter.
+      discard v.insert(v.`end`(), 10)
+      check v == @[1, 2, 3, 9, 10].toCppVector()
 
-    # Below, using .begin() instead of .cBegin() also
-    # works.. because of the CppVectorIteratorToCppVectorConstIterator converter.
-    discard v.insert(v.begin(), 10)
-    check v == @[10, 9, 1, 2, 3].toCppVector()
-
-    # insert elem at the end
-    v = @[1, 2, 3].toCppVector()
-    discard v.insert(v.cEnd(), 9)
-    check v == @[1, 2, 3, 9].toCppVector()
-
-    # Below, using .`end`() instead of .cEnd() also
-    # works.. because of the CppVectorIteratorToCppVectorConstIterator converter.
-    discard v.insert(v.`end`(), 10)
-    check v == @[1, 2, 3, 9, 10].toCppVector()
-
-    # insert copies of a val
-    v = @[1, 2, 3].toCppVector()
-    discard v.insert(v.cEnd(), 3, 111)
-    check v == @[1, 2, 3, 111, 111, 111].toCppVector()
-
-    # insert elements from a CppVector range
-    v = @[1, 2, 3].toCppVector()
-    # Below copies the whole CppVector and appends to itself at the end.
-    discard v.insert(v.cEnd(), v.cBegin(), v.cEnd())
-    check v == @[1, 2, 3, 1, 2, 3].toCppVector()
-
-    # Below is a long-winded way to copy one CppVector to another.
-    var
-      v2: CppVector[int]
-    discard v2.insert(v2.cEnd(), v.cBegin(), v.cEnd())
-    check v2 == v
-
-  test "iterator arithmetic":
-    var
+      # insert copies of a val
       v = @[1, 2, 3].toCppVector()
+      discard v.insert(v.cEnd(), 3, 111)
+      check v == @[1, 2, 3, 111, 111, 111].toCppVector()
 
-    # Insert elem after the first element.
-    discard v.insert(v.cBegin()+1, 9)
-    check v == @[1, 9, 2, 3].toCppVector()
+      # insert elements from a CppVector range
+      v = @[1, 2, 3].toCppVector()
+      # Below copies the whole CppVector and appends to itself at the end.
+      discard v.insert(v.cEnd(), v.cBegin(), v.cEnd())
+      check v == @[1, 2, 3, 1, 2, 3].toCppVector()
 
-    # Insert elem before the last element.
-    discard v.insert(v.cEnd()-1, 9)
-    check v == @[1, 9, 2, 9, 3].toCppVector()
+      # Below is a long-winded way to copy one CppVector to another.
+      var
+        v2: CppVector[int]
+      discard v2.insert(v2.cEnd(), v.cBegin(), v.cEnd())
+      check v2 == v
 
-  test "swap two vectors":
-    var
-      v1 = @['a', 'b', 'c'].toCppVector()
-      v2 = @['w', 'x', 'y', 'z'].toCppVector()
+    test "iterator arithmetic":
+      var
+        v = @[1, 2, 3].toCppVector()
 
-    v1.swap(v2)
-    check v1 == @['w', 'x', 'y', 'z'].toCppVector()
-    check v2 == @['a', 'b', 'c'].toCppVector()
+      # Insert elem after the first element.
+      discard v.insert(v.cBegin()+1, 9)
+      check v == @[1, 9, 2, 3].toCppVector()
+
+      # Insert elem before the last element.
+      discard v.insert(v.cEnd()-1, 9)
+      check v == @[1, 9, 2, 9, 3].toCppVector()
+
+    test "swap two vectors":
+      var
+        v1 = @['a', 'b', 'c'].toCppVector()
+        v2 = @['w', 'x', 'y', 'z'].toCppVector()
+
+      v1.swap(v2)
+      check v1 == @['w', 'x', 'y', 'z'].toCppVector()
+      check v2 == @['a', 'b', 'c'].toCppVector()
+
+test()


### PR DESCRIPTION
1. Generated infix C++ expressions are verbatim text, brutal violations of grouping and precedence were observed under Nim 2.x!!! For example, Nim codegen tried to negate "x == y" as "!x == y". That's why I insulated all occurences with ().

2. Araq recommended to avoid construction of wrapped STL objects in top-level scope (https://forum.nim-lang.org/t/12518). Fixed unit tests to follow this recommendation.

After performing steps (1,2) cppstl builds and passes all tests when compiled with Nim 2.0.0, 2.0.2 and 2.0.4

PS. It still fails on latest Nim 2.0.8 release because of C++ compile-time errors related to unary 'operator*', but this is unrelated issue.